### PR TITLE
accept an id param for video comversion instead of video&audio urls

### DIFF
--- a/videoCombiner/__init__.py
+++ b/videoCombiner/__init__.py
@@ -1,18 +1,52 @@
 import base64
+import os
 import subprocess
 import tempfile
-import os
 import time
 
-def generateVideo(videoUrl,audioUrl):
+
+def ffmpeg(args):
     start = time.time()
-    with tempfile.TemporaryDirectory() as tmpdirname:
-        newPath = os.path.join(tmpdirname, "combined.mp4")
-        # combine video and audio into one file using ffmpeg
-        subprocess.run(["ffmpeg", "-i", videoUrl, "-i", audioUrl, "-c:v", "copy", "-c:a", "copy", "-map", "0:v:0", "-map", "1:a:0", newPath], capture_output=True)
-        # encode video to base64
-        with open(newPath, "rb") as videoFile:
-            encoded_string = base64.b64encode(videoFile.read())
+
+    with tempfile.TemporaryDirectory() as tempdir:
+        new_path = os.path.join(tempdir, "combined.mp4")
+
+        args.insert(0, "ffmpeg")
+        args.append(new_path)
+
+        res = subprocess.run(args, capture_output=True)
+
+        if res.returncode == 0:
+            with open(new_path, "rb") as f:
+                encoded_string = base64.b64encode(f.read())
+        else:
+            encoded_string = None
+
     end = time.time()
+
     print(f"Video generation took {end - start} seconds")
+
     return encoded_string
+
+
+def combine_videos(video_url, audio_url):
+    return ffmpeg(
+        [
+            "-i",
+            video_url,
+            "-i",
+            audio_url,
+            "-c:v",
+            "copy",
+            "-c:a",
+            "copy",
+            "-map",
+            "0:v:0",
+            "-map",
+            "1:a:0",
+        ]
+    )
+
+
+def video_from_id(id):
+    return ffmpeg(["-i", f"https://v.redd.it/{id}/DASHPlaylist.mpd", "-c", "copy"])

--- a/vxreddit.py
+++ b/vxreddit.py
@@ -285,13 +285,13 @@ def get_video():
     if not video_url:
         abort(400)
 
+    if not audio_url:
+        return redirect(video_url)
+
     if not video_url.startswith("https://v.redd.it/") or not audio_url.startswith(
         "https://v.redd.it/"
     ):
         abort(400)
-
-    if not audio_url:
-        return redirect(video_url)
 
     return send_video(videoCombiner.combine_videos(video_url, audio_url))
 

--- a/vxreddit.py
+++ b/vxreddit.py
@@ -260,8 +260,25 @@ def build_stats_line(embed_info):
     return stats_line
 
 
+def send_video(b64):
+    if not b64:
+        abort(400)
+
+    return send_file(io.BytesIO(base64.b64decode(b64)), mimetype="video/mp4")
+
+
 @app.route("/redditvideo.mp4")
 def get_video():
+    renderer = config.currentConfig["MAIN"]["videoConversion"]
+
+    if renderer != "local":
+        return redirect(f"{renderer}?{request.query_string.decode()}", code=307)
+
+    id = request.args.get("id", "")
+
+    if id:
+        return send_video(videoCombiner.video_from_id(id))
+
     video_url = request.args.get("video_url", "")
     audio_url = request.args.get("audio_url", "")
 
@@ -276,19 +293,7 @@ def get_video():
     if not audio_url:
         return redirect(video_url)
 
-    if config.currentConfig["MAIN"]["videoConversion"] == "local":
-        b64 = videoCombiner.generateVideo(video_url, audio_url)
-
-        return send_file(io.BytesIO(base64.b64decode(b64)), mimetype="video/mp4")
-    else:
-        renderer = config.currentConfig["MAIN"]["videoConversion"]
-
-        video_url = urllib.parse.quote(video_url, safe="")
-        audio_url = urllib.parse.quote(audio_url, safe="")
-
-        return redirect(
-            f"{renderer}?video_url={video_url}&audio_url={audio_url}", code=307
-        )
+    return send_video(videoCombiner.combine_videos(video_url, audio_url))
 
 
 def get_embed_info(post_id, comment_id):


### PR DESCRIPTION
Allows using `/redditvideo.mp4?id=[video_id]` instead of `?video_url=...&audio_url=...`, since ffmpeg supports dash urls

Example:
`?video_url=https://v.redd.it/fs1sgj08nnah1/CMAF_720.m3u8&audio_url=https://v.redd.it/fs1sgj08nnah1/CMAF_AUDIO_128.m3u8` -> `?id=fs1sgj08nnah1`